### PR TITLE
fix: generate the correct command to run tests on Typescript

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -220,6 +220,10 @@ export async function setup() {
   let assertionPluginCall: undefined | string
   const { importerFunctionCall } = PROJECT_TYPES.find(({ name }) => name === projectType) || {}
 
+  if (isTypeScriptProject) {
+    packagesToInstall.push('ts-node')
+  }
+
   /**
    * Collect import calls for reporters
    */
@@ -356,11 +360,14 @@ export async function setup() {
   }
 
   if (!response || response.status === 0) {
+    let loaderOption = ''
+    if (projectType === 'TypeScript') loaderOption = '-r ts-node/register '
+    if (projectType === 'TypeScript ESM') loaderOption = '--loader=ts-node/esm '
     console.log(logger.colors.green(`${icons.tick} Configured japa successfully`))
     console.log(
       `${icons.pointer} Run ${logger.colors
         .dim()
-        .underline(`"node ${testFileName}"`)} to execute tests`
+        .underline(`"node ${loaderOption}${testFileName}"`)} to execute tests`
     )
   } else {
     console.log(logger.colors.red(`${icons.cross} Packages installation failed`))


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/japa/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

#1 

### ❓ Type of change

- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This fixes the issue #1 

- if the project is in Typescript, then `ts-node` is installed.
- if `Typescript` is chosen then the command to run tests is `node -r ts-node/register bin/test.ts`
- if `Typescript ESM` is chosen then the command to run tests is `node --loader=ts-node/esm bin/test.ts`

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
