### PR TITLE
fix: set default installation directory to cwd

### DIFF
--- a/src/install_japa.ts
+++ b/src/install_japa.ts
@@ -44,7 +44,7 @@ export class InstallJapa extends BaseCommand {
   /**
    * Destination directory
    */
-  @args.string({ description: 'Destination', default: process.cwd() })
+  @args.string({ description: 'Destination', required: false })
   declare destination: string
 
   /**

--- a/src/install_japa.ts
+++ b/src/install_japa.ts
@@ -45,7 +45,7 @@ export class InstallJapa extends BaseCommand {
   /**
    * Destination directory
    */
-  @args.string({ description: 'Destination', default: 'process.cwd()' })
+  @args.string({ description: 'Destination', default: process.cwd() })
   declare destination: string
 
   /**

--- a/src/install_japa.ts
+++ b/src/install_japa.ts
@@ -8,7 +8,6 @@
  */
 
 import { Edge } from 'edge.js'
-import { cwd } from 'node:process'
 import { existsSync } from 'node:fs'
 import gradient from 'gradient-string'
 import { fileURLToPath } from 'node:url'
@@ -335,7 +334,7 @@ export class InstallJapa extends BaseCommand {
       this.packageManager = detectPackageManager()?.name || 'npm'
     }
     if (!this.destination) {
-      this.destination = cwd()
+      this.destination = process.cwd()
     }
   }
 


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/japa/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Fixes #4 and reverts the bug introduced in [83d09f6](https://github.com/japa/create-japa/commit/83d09f607db6d027d5cee548e1f537e3a17dad13#diff-8ca2185ef36780874176188ae167b29dcc4cfc35687fc0d36bf44114dac69b32R48) (default argument set to `'process.cwd()'` instead of `process.cwd()`).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
