### PR TITLE
Fix TS test running when project is first initialized with japa

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.16.0, 20.x]
+        node-version: ["lts/iron", "lts/jod", "latest"]
 
     steps:
     - name: Checkout code
@@ -37,7 +37,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        node-version: [18.16.0, 20.x]
+        node-version: ["lts/iron", "lts/jod", "latest"]
 
     steps:
     - name: Checkout code

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Setup japa inside an existing Node.js project",
   "version": "2.1.3",
   "engines": {
-    "node": ">=18.16.0"
+     "node": ">=20.9.0"
   },
   "main": "build/index.js",
   "type": "module",

--- a/src/install_japa.ts
+++ b/src/install_japa.ts
@@ -343,6 +343,7 @@ export class InstallJapa extends BaseCommand {
      */
     const tsConfigJson = JSON.parse(await readFile(tsConfigPath, 'utf-8'))
     tsConfigJson.compilerOptions = {
+      ...tsConfigJson.compilerOptions,
       module: 'NodeNext',
     }
 

--- a/src/install_japa.ts
+++ b/src/install_japa.ts
@@ -279,7 +279,7 @@ export class InstallJapa extends BaseCommand {
 
     const testScript =
       this.projectType === 'typescript'
-        ? 'node --loader ts-node/esm --enable-source-maps bin/test.ts'
+        ? 'node --import ts-node-maintained/register/esm --enable-source-maps bin/test.ts'
         : 'node bin/test.js'
 
     /**
@@ -289,8 +289,10 @@ export class InstallJapa extends BaseCommand {
       await this.#createNewPkgJson(basename(this.destination), testScript)
       await this.#installPackages([
         ...this.#packageToInstall.map((pkg) => `${pkg}@latest`),
-        'ts-node',
+        'ts-node-maintained',
+        '@swc/core',
         'typescript',
+        '@adonisjs/tsconfig',
       ])
 
       return
@@ -310,6 +312,12 @@ export class InstallJapa extends BaseCommand {
     this.logger.action('update package.json').succeeded()
     await this.#installPackages(this.#packageToInstall.map((pkg) => pkg + '@latest'))
   }
+
+  /**
+   * Create or update the package.json file based upon the user selections
+   */
+
+  async #createTSconfig() {}
 
   /**
    * Print final instructions to the user

--- a/tests/install.spec.ts
+++ b/tests/install.spec.ts
@@ -265,7 +265,7 @@ test.group('install', (group) => {
 
     assert.deepEqual(pkg.type, 'module')
     assert.deepEqual(pkg.scripts, {
-      test: 'node --loader ts-node/esm --enable-source-maps bin/test.ts',
+      test: 'node --import ts-node-maintained/register/esm --enable-source-maps bin/test.ts',
     })
   })
 
@@ -285,7 +285,7 @@ test.group('install', (group) => {
 
     assert.deepEqual(pkg.type, 'module')
     assert.deepEqual(pkg.scripts, {
-      test: 'node --loader ts-node/esm --enable-source-maps bin/test.ts',
+      test: 'node --import ts-node-maintained/register/esm --enable-source-maps bin/test.ts',
     })
     assert.deepEqual(pkg.name, 'foo')
     assert.deepEqual(pkg.description, 'blabla')

--- a/tests/install.spec.ts
+++ b/tests/install.spec.ts
@@ -312,4 +312,45 @@ test.group('install', (group) => {
       process.env.npm_config_user_agent = undefined
     })
     .disableTimeout()
+
+  test('should create tsconfig.json if ts is selected and no tsconfig exists', async ({
+    assert,
+    fs,
+  }) => {
+    const command = await kernel.create(InstallJapa, [fs.basePath])
+
+    trapPrompts(command)
+
+    await command.exec()
+
+    await assert.fileExists('tsconfig.json')
+    const config = await fs.contentsJson('tsconfig.json')
+
+    assert.deepEqual(config.compilerOptions.module, 'NodeNext')
+  })
+
+  test('should update existing tsconfig.json if exists with correct module setting', async ({
+    assert,
+    fs,
+  }) => {
+    await fs.create(
+      'tsconfig.json',
+      JSON.stringify({ compilerOptions: { target: 'ESNext', lib: ['ESNext'] } })
+    )
+
+    kernel.ui.switchMode('raw')
+
+    const command = await kernel.create(InstallJapa, [fs.basePath])
+
+    trapPrompts(command)
+
+    await command.exec()
+
+    await assert.fileExists('tsconfig.json')
+    const config = await fs.contentsJson('tsconfig.json')
+
+    assert.deepEqual(config.compilerOptions.target, 'ESNext')
+    assert.deepEqual(config.compilerOptions.lib[0], 'ESNext')
+    assert.deepEqual(config.compilerOptions.module, 'NodeNext')
+  })
 })


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/japa/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

#6 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

When using this script with the TS options for initializing a project for example with the following method:

```
npm init japa@latest .
```

the `npm run test` command will throw some errors because:

1. It's using `ts-node` which has some old esm flags enabled
2. It does not initialize a proper `tsconfig.json` so the ts compiler does not know how to run the test command

So to fix this, the PR has the following changes:

1.  Changed `ts-node` for `ts-node-maintained`, and updated the test command accordingly
2.  Added `@swc/core` devDependency so the ts compiler can transpile the code
3.  If the project is using TypeScript, the cli will create a basic `tsconfig.json` file with the following minimal settings:

```JSON
{
   "compilerOptions": {
     "module": "NodeNext",
    }
}
```
this way the `test` command will run properly.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
